### PR TITLE
remove port 5000 dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV GROQ_API_KEY=$GROQ_API_KEY
 ENV FLASK_APP=flask_interface.app
 ENV FLASK_RUN_HOST=0.0.0.0
 
-EXPOSE 5000
+EXPOSE 80
 
-CMD ["gunicorn", "-b", "0.0.0.0:5000", "flask_interface.app:app"]
+COPY nginx.conf /etc/nginx/nginx.conf
+
+CMD ["gunicorn", "-b", "0.0.0.0:80", "flask_interface.app:app"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;  # Proxy to Gunicorn on port 8000
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
to properly host lugha on lugha.xyz without url forwarding, it is easier to not require port 5000 in the target url