### PR TITLE
Rename Langua to Lugha

### DIFF
--- a/src/evaluation_utils/evaluate.py
+++ b/src/evaluation_utils/evaluate.py
@@ -103,16 +103,18 @@ class LanguageEvaluator:
     def create_evaluation_prompt(self, conversation: str, language: str) -> str:
         return (
             f"As an expert {language} language evaluator, analyze this conversation "
-            f"and provide detailed metrics:\n\n"
-            f"1. Overall Proficiency Score in % \n"
-            f"2. Grammar Accuracy in %\n"
-            f"3. Vocabulary Range in %\n"
-            f"4. Communication Effectiveness in %\n"
-            f"5. Cultural Understanding in %\n\n"
-            f"Then provide:\n"
-            f"- Key Strengths: List 2-3 main strengths\n"
-            f"- Areas for Improvement: List 2-3 specific areas\n"
-            f"- Actionable Recommendations: Provide 2-3 concrete practice suggestions\n\n"
+            f"and provide:\n\n"
+            f"1. Brief Proficiency Overview:\n"
+            f"- Overall Score: __%%\n"
+            f"Grammar Accuracy: __ %%\n"
+            f"- Communication Effectiveness: __%%\n\n"
+            f"2. Top 3-5 Specific Mistakes Found:\n"
+            f"For each mistake, provide:\n"
+            f"- Original phrase/sentence\n"
+            f"- Error type (grammar/vocabulary/usage)\n"
+            f"- Correction with brief explanation\n\n"
+            f"3. Quick Improvement Tips:\n"
+            f"- Two focused practice suggestions\n\n"
             f"Conversation to evaluate:\n{conversation}"
         )
 

--- a/src/flask_interface/templates/admin.html
+++ b/src/flask_interface/templates/admin.html
@@ -12,7 +12,7 @@
     <div class="container">
         <div class="logo-container">
             <div class="logo-icon">L</div>
-            <div class="logo-text">Langua</div>
+            <div class="logo-text">Lugha</div>
         </div>
         <h1 class="welcome-title">Admin <span>Panel</span></h1>
         <p class="welcome-subtitle">View User Conversation History</p>

--- a/src/flask_interface/templates/chat_interface.html
+++ b/src/flask_interface/templates/chat_interface.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Langua Chat Interface</title>
+    <title>Lugha Chat Interface</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/theme.css">
     <link rel="stylesheet" href="/static/css/chat-interface.css">
@@ -17,14 +17,14 @@
             <header class="sidebar-header">
                 <div class="logo-container">
                     <div class="logo-icon">L</div>
-                    <div class="logo-text">Langua</div>
+                    <div class="logo-text">Lugha</div>
                 </div>
                 <button id="toggle-sidebar" class="toggle-sidebar-button">
                     <i data-feather="chevron-left"></i>
                 </button>
             </header>
             <section class="welcome-message">
-                <h2>Welcome, <span id="user-name">User </span>!</h2>
+                <h2>Welcome, <span id="user-name">User  </span>!</h2>
                 <p>Let's start learning together.</p>
             </section>
             <section class="ally-section">
@@ -108,7 +108,7 @@
         $(document).ready(function() {
             const urlParams = new URLSearchParams(window.location.search);
             const username = urlParams.get('username');
-            const assistantName = urlParams.get('assistantName') || 'Ally'; 
+            const Lugha = 'Lugha'; 
             let language = urlParams.get('language');
             let theme = urlParams.get('theme');
             let emoji = urlParams.get('emoji');
@@ -129,7 +129,7 @@
                 data: JSON.stringify({ username, language, theme, emoji }),
                 success: function(data) {
                     if (data.response) {
-                        $('#chat-box').append('<div class="message-bubble bot-message"><strong>' + assistantName + ':</strong> ' + data.response + '</div>');
+                        $('#chat-box').append('<div class="message-bubble bot-message"><strong>' + Lugha + ':</strong> ' + data.response + '</div>');
                     }
                 },
                 error: function(err) {
@@ -152,7 +152,7 @@
                         data: JSON.stringify({ username, message, language }),
                         success: function(data) {
                             if (data.response) {
-                                $('#chat-box').append(`<div class="message-bubble bot-message"><strong>${assistantName}:</strong> ${data.response}</div>`);
+                                $('#chat-box').append(`<div class="message-bubble bot-message"><strong>${Lugha}:</strong> ${data.response}</div>`);
                                 $('#chat-box').scrollTop($('#chat-box')[0].scrollHeight);
                             } else {
                                 console.warn('No response from bot');
@@ -239,7 +239,7 @@
                     data: JSON.stringify({ username, language, theme, emoji }), 
                     success: function(data) {
                         if (data.response) {
-                            $('#chat-box').append('<div class="message-bubble bot-message"><strong>Ally:</strong> ' + data.response + '</div>');
+                            $('#chat-box').append('<div class="message-bubble bot-message"><strong>' + Lugha + ':</strong> ' + data.response + '</div>');
                             $('#chat-box').scrollTop($('#chat-box')[0].scrollHeight);
                         }
                     },

--- a/src/flask_interface/templates/track_progress.html
+++ b/src/flask_interface/templates/track_progress.html
@@ -12,7 +12,7 @@
     <div class="container">
         <div class="logo-container">
             <div class="logo-icon">L</div>
-            <div class="logo-text">Langua</div>
+            <div class="logo-text">Lugha</div>
         </div>
         <h1 class="welcome-title">Track Your <span>Progress</span></h1>
         <p class="welcome-subtitle">Review your language learning journey</p>

--- a/src/flask_interface/templates/welcome.html
+++ b/src/flask_interface/templates/welcome.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Welcome to Langua - Your AI Language Coach</title>
+    <title>Welcome to Lugha - Your AI Language Coach</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/theme.css') }}">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -14,9 +14,9 @@
         <div class="welcome-card">
             <div class="logo-container">
                 <div class="logo-icon">L</div>
-                <div class="logo-text">Langua</div>
+                <div class="logo-text">Lugha</div>
             </div>
-            <h1 class="welcome-title">Welcome to <span>Langua</span></h1>
+            <h1 class="welcome-title">Welcome to <span>Lugha</span></h1>
             <p class="welcome-subtitle">Your AI-powered Language Coach</p>
             <div class="message-card">
                 <h2 class="message-title"><i data-feather="message-square"></i> Build your tailored language coach 'Ally'</h2>


### PR DESCRIPTION
- Logo Update: Changed the logo name from "Langua" to "Lugha."
- Chat Interface Update: Fixed the bot's name in the interface to "Lugha."
- Enhanced Evaluation Prompts: Improved the evaluation prompts to better handle user mistakes and provide a brief correction with actionable feedback.