### PR TITLE
enforce HTTPS & TLS 1.2+ for Web Speech API compatibility

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -2,17 +2,14 @@ server {
     listen 80;
     server_name lugha.xyz;
 
-    location / {
-        proxy_pass http://lugha:8000;  # Proxy to Gunicorn on port 8000
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
 
     location /.well-known/acme-challenge/ {
         alias /var/www/html/.well-known/acme-challenge/;
         try_files $uri =404;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
     }
 }
 
@@ -22,6 +19,17 @@ server {
 
     ssl_certificate /etc/letsencrypt/live/lugha.xyz/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/lugha.xyz/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers 'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384';
+    ssl_prefer_server_ciphers on;
+
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 1.1.1.1 valid=300s;
+    resolver_timeout 5s;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
     location / {
         proxy_pass http://lugha:8000;


### PR DESCRIPTION
Updates the nginx.conf

- Forced HTTPS – All http traffic now redirects to https.

- Stronger SSL – TLS 1.2/1.3 only, modern ciphers, HSTS header.

- Android Fix – Removed weak ciphers for better compatibility.